### PR TITLE
BRP-15142: updating stoplight\'s Sinatra version to 2.2.3

### DIFF
--- a/stoplight-admin.gemspec
+++ b/stoplight-admin.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.push(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name = 'stoplight-admin'
-  gem.version = '0.3.5'
+  gem.version = '0.3.6'
   gem.summary = 'A simple administration interface for Stoplight.'
   gem.description = gem.summary
   gem.homepage = 'https://github.com/bolshakov/stoplight-admin'
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
 
   {
     'haml' => '5.0.4',
-    'sinatra-contrib' => '2.2.0'
+    'sinatra-contrib' => '2.2.3'
   }.each do |name, version|
     gem.add_dependency(name, "~> #{version}")
   end


### PR DESCRIPTION
BRP-15142: updating stoplight\'s Sinatra version to 2.2.3 to address CVE-2022-45442

```
Name: sinatra
Version: 2.2.0
CVE: CVE-2022-45442
GHSA: GHSA-2x8x-jmrp-phxw
Criticality: High
URL: https://github.com/sinatra/sinatra/security/advisories/GHSA-2x8x-jmrp-phxw
Description:

  An issue was discovered in Sinatra 2.0 before 2.2.3 and 3.0 before 3.0.4. An
  application is vulnerable to a reflected file download (RFD) attack that sets
  the Content-Disposition header of a response when the filename is derived
  from user-supplied input.

Solution: upgrade to '~> 2.2.3', '>= 3.0.4'
```